### PR TITLE
fix: 📌 add replace commands to go.mod files

### DIFF
--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -1,3 +1,11 @@
 module nx-go-playground/api
 
 go 1.21
+
+replace nx-go-playground/logger => ../../libs/logger
+replace nx-go-playground/math => ../../libs/math
+
+require (
+	nx-go-playground/logger v0.0.0-00010101000000-000000000000
+	nx-go-playground/math v0.0.0-00010101000000-000000000000
+)

--- a/apps/cli/go.mod
+++ b/apps/cli/go.mod
@@ -1,3 +1,15 @@
 module nx-go-playground/cli
 
 go 1.21
+
+replace nx-go-playground/logger => ../../libs/logger
+replace nx-go-playground/math => ../../libs/math
+replace nx-go-playground/geometry => ../../libs/geometry
+
+require (
+	nx-go-playground/geometry v0.0.0-00010101000000-000000000000
+	nx-go-playground/logger v0.0.0-00010101000000-000000000000
+)
+
+require nx-go-playground/math v0.0.0-00010101000000-000000000000 // indirect
+

--- a/libs/geometry/go.mod
+++ b/libs/geometry/go.mod
@@ -1,3 +1,7 @@
 module nx-go-playground/geometry
 
 go 1.21
+
+replace nx-go-playground/math => ../math
+
+require nx-go-playground/math v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
This is currently an ongoing issue with go.work configurations in https://github.com/golang/go/issues/50750

As discussed in https://github.com/nx-go/nx-go/issues/127 we should update the demo to demonstrate an actual setup so that other engineers running across this issue can see a clear demonstration of how it needs to be fixed.

For example `nx-go-playground/math` needs to be replaced in both `nx-go-playground/cli` and `nx-go-playground/geometry` even though it is only depended upon in `nx-go-playground/geometry` as the entire chain needs to be replaced in order for `go get` to work properly.

Note that this is not required for `go build` or `go run`. Just for updating dependencies.